### PR TITLE
Fix hanging tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,8 @@ extras_require = {
         'freezegun>=0.1.18',
         'py>=1.4.20',
         'pytest>=2.5.2',
-        'moto>=0.3.9'
+        'moto>=0.3.9',
+        'httpretty==0.8.6'
     ]
 }
 


### PR DESCRIPTION
A dependency of `moto` called `httpretty` was leading to the hanging
tests. Downgrading it from `0.8.7` to `0.8.6` by freezing its version
fixes the issue.

Refs #9