### PR TITLE
Implement Content-Type check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,17 @@
 Changelog
 ---------
 
+2.0.0 (July 11th, 2018)
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Add Content-Type validation to AmazonS3SignedRequest.
+
+1.0.0 (December 5th, 2017)
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Switch to boto3.
+- Drop support for boto.
+
 0.2.1 (March 5th, 2015)
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,7 @@ Creating form fields for a signed Amazon S3 POST request
     #     'AWSAccessKeyId': 'your-aws-access-key-id',
     #     'success_action_status': '201',
     #     'acl': 'public-read',
+    #     'Content-Type': 'image/png',
     #     'key': u'f6c157e1-1a1a-4418-99fe-3362dcf7b1ea/images/my-image.jpg',
     #     'Signature': 'generated-signature',
     #     'Policy': 'generated-policy-document'

--- a/pontus/__init__.py
+++ b/pontus/__init__.py
@@ -10,4 +10,4 @@
 from .amazon_s3_file_validator import AmazonS3FileValidator  # noqa
 from .amazon_s3_signed_request import AmazonS3SignedRequest  # noqa
 
-__version__ = '1.0.0'
+__version__ = '2.0.0'

--- a/pontus/amazon_s3_signed_request.py
+++ b/pontus/amazon_s3_signed_request.py
@@ -39,6 +39,7 @@ class AmazonS3SignedRequest(object):
         assert signed_request.form_fields == {
             'AWSAccessKeyId': 'your-aws-access-key',
             'acl': 'public-read',
+            'Content-Type': 'image/png',
             'key': 'my/file.jpg',
             'Policy': 'generated-policy-document',
             'success_action_status': '201',
@@ -115,6 +116,7 @@ class AmazonS3SignedRequest(object):
         return {
             'AWSAccessKeyId': self.session.get_credentials().access_key,
             'acl': self.acl,
+            'Content-Type': self.mime_type,
             'key': self.key_name,
             'Policy': policy,
             'success_action_status': self.success_action_status,
@@ -129,7 +131,7 @@ class AmazonS3SignedRequest(object):
                 {'bucket': self.bucket.name},
                 {'key': self.key_name},
                 {'acl': self.acl},
-                ['starts-with', '$Content-Type', ''],
+                {'Content-Type': self.mime_type},
                 ['content-length-range', 0, self.max_content_length],
                 {'success_action_status': self.success_action_status}
             ]

--- a/tests/test_amazon_s3_signed_request.py
+++ b/tests/test_amazon_s3_signed_request.py
@@ -48,7 +48,7 @@ class TestAmazonS3SignedRequest(object):
                 {'bucket': 'test-bucket'},
                 {'key': 'test-unvalidated-uploads/file_name.png'},
                 {'acl': 'private'},
-                ['starts-with', '$Content-Type', ''],
+                {'Content-Type': 'image/png'},
                 ['content-length-range', 0, 20971520],
                 {'success_action_status': '201'},
             ]
@@ -68,6 +68,7 @@ class TestAmazonS3SignedRequest(object):
         assert signed_request.form_fields == {
             'AWSAccessKeyId': 'test-key',
             'acl': 'private',
+            'Content-Type': 'image/png',
             'key': 'test-unvalidated-uploads/file_name.png',
             'Policy': 'policy',
             'success_action_status': '201',


### PR DESCRIPTION
Implement policy restriction that enforces the file Content-Type to
be same as mime_type given to AmazonS3SignedRequest at initialization.

Previously, the mime_type argument was ignored and
Content-Type was required, but could be anything.