### PR TITLE
Add new_file_acl argument to AmazonS3FileValidator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+2.2.0 (January 29th, 2019)
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Add new_file_acl argument to AmazonS3FileValidator.
+
+
 2.1.0 (November 5th, 2018)
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/pontus/__init__.py
+++ b/pontus/__init__.py
@@ -10,4 +10,4 @@
 from .amazon_s3_file_validator import AmazonS3FileValidator  # noqa
 from .amazon_s3_signed_request import AmazonS3SignedRequest  # noqa
 
-__version__ = '2.1.0'
+__version__ = '2.2.0'

--- a/pontus/amazon_s3_file_validator.py
+++ b/pontus/amazon_s3_file_validator.py
@@ -59,6 +59,10 @@ class AmazonS3FileValidator(object):
     :param new_file_prefix:
         Prefix to be set to the new file that is copied during validation.
 
+    :param new_file_acl:
+        Canned ACL set to the new file that is copied during validation.
+        Defaults to 'public-read'.
+
     """
     def __init__(
         self,
@@ -66,7 +70,8 @@ class AmazonS3FileValidator(object):
         bucket,
         validators=[],
         delete_unvalidated_file=True,
-        new_file_prefix=''
+        new_file_prefix='',
+        new_file_acl='public-read',
     ):
         self.errors = []
         self.obj = bucket.Object(key_name)
@@ -81,6 +86,7 @@ class AmazonS3FileValidator(object):
         self.validators = validators
         self.delete_unvalidated_file = delete_unvalidated_file
         self.new_file_prefix = new_file_prefix
+        self.new_file_acl = new_file_acl
 
     def validate(self):
         """
@@ -119,7 +125,7 @@ class AmazonS3FileValidator(object):
             'Bucket': self.bucket.name,
             'Key': self.obj.key
         })
-        new_obj.Acl().put(ACL='public-read')
+        new_obj.Acl().put(ACL=self.new_file_acl)
         if self.delete_unvalidated_file:
             self.obj.delete()
         self.obj = new_obj

--- a/tests/test_amazon_s3_file_validator.py
+++ b/tests/test_amazon_s3_file_validator.py
@@ -11,6 +11,11 @@ from pontus.validators import BaseValidator
 HOUR_IN_SECONDS = 60 * 60
 
 
+class AnyDict:
+    def __eq__(self, other):
+        return isinstance(other, dict)
+
+
 class CustomValidator(BaseValidator):
     def __call__(self, obj):
         if obj.key != 'test-unvalidated-uploads/images/hello.jpg':
@@ -46,6 +51,17 @@ class TestAmazonS3FileValidator(object):
             key_name=key_name,
             bucket=bucket,
             new_file_prefix='validated-uploads/'
+        )
+
+
+    @pytest.fixture
+    def amazon_s3_file_validator_with_acl(self, bucket):
+        key_name = 'test-unvalidated-uploads/images/hello.jpg'
+        boto3.resource('s3').Object(bucket.name, key_name).put(Body='test')
+        return AmazonS3FileValidator(
+            key_name=key_name,
+            bucket=bucket,
+            new_file_acl='private',
         )
 
     @pytest.fixture
@@ -149,6 +165,20 @@ class TestAmazonS3FileValidator(object):
         assert boto3.resource('s3').Object(
               bucket.name, 'validated-uploads/hello.jpg'
         ).get()
+
+    def test_validate_uses_new_file_acl(
+        self,
+        amazon_s3_file_validator_with_acl,
+        bucket
+    ):
+        amazon_s3_file_validator_with_acl.validate()
+
+        assert boto3.resource('s3').Object(
+              bucket.name, 'images/hello.jpg'
+        ).Acl().grants == [{
+            'Grantee': AnyDict(),
+            'Permission': 'FULL_CONTROL'
+        }]
 
     def test_repr(self, amazon_s3_file_validator):
         assert repr(amazon_s3_file_validator) == (


### PR DESCRIPTION
Backwards compatible.
I will release a new version after this.

I need the new file to have the `'private'` ACL. Other choice would be to add a flag `skip_set_new_file_acl` or similar, which would skip the code where ACL is set. However, I prefer a more explicit and flexible solution. My solution has a drawback, that setting the ACL to `'private'` is unnecessary because the object is already private.