### PR TITLE
feat: Add support for preserving content type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           name: Install OS dependencies
           command: |
             apt-get update -qq
-            apt-get install -y --no-install-recommends python-dev locales
+            apt-get install -y --no-install-recommends python-dev-is-python3 locales
             echo en_US.UTF-8 UTF-8 >> /etc/locale.gen
             locale-gen
             pip install tox

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+4.1.0 (August 14th, 2024)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Preserve original file content type in AmazonS3FileValidator.
+- Combine ACL update to copy operation in AmazonS3FileValidator.
+
 4.0.0 (February 24th, 2021)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/pontus/__init__.py
+++ b/pontus/__init__.py
@@ -10,4 +10,4 @@
 from .amazon_s3_file_validator import AmazonS3FileValidator  # noqa
 from .amazon_s3_signed_request import AmazonS3SignedRequest  # noqa
 
-__version__ = '4.0.0'
+__version__ = '4.1.0'

--- a/pontus/amazon_s3_file_validator.py
+++ b/pontus/amazon_s3_file_validator.py
@@ -120,12 +120,19 @@ class AmazonS3FileValidator(object):
         new_name = self.new_file_prefix + self.obj.key[
             len(current_app.config.get('AWS_UNVALIDATED_PREFIX')):
         ]
+        ExtraArgs = {
+            'ACL': self.new_file_acl,
+        }
+        if self.obj.content_type:
+            ExtraArgs['ContentType'] = self.obj.content_type
         new_obj = self.bucket.Object(new_name)
-        new_obj.copy({
-            'Bucket': self.bucket.name,
-            'Key': self.obj.key
-        })
-        new_obj.Acl().put(ACL=self.new_file_acl)
+        new_obj.copy(
+            {
+                'Bucket': self.bucket.name,
+                'Key': self.obj.key,
+            },
+            ExtraArgs=ExtraArgs,
+        )
         if self.delete_unvalidated_file:
             self.obj.delete()
         self.obj = new_obj

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ extras_require = {
         'freezegun>=0.1.18',
         'py>=1.4.20',
         'pytest>=2.5.2',
-        'moto>=1.3.7',
+        'moto[s3]>=4,<5',
     ]
 }
 

--- a/tests/test_amazon_s3_file_validator.py
+++ b/tests/test_amazon_s3_file_validator.py
@@ -26,7 +26,10 @@ class TestAmazonS3FileValidator(object):
     @pytest.fixture
     def amazon_s3_file_validator(self, bucket):
         key_name = 'test-unvalidated-uploads/images/hello.jpg'
-        boto3.resource('s3').Object(bucket.name, key_name).put(Body='test')
+        boto3.resource('s3').Object(bucket.name, key_name).put(
+            Body='test',
+            ContentType='application/custom.test',
+        )
         return AmazonS3FileValidator(
             key_name=key_name,
             bucket=bucket,
@@ -137,6 +140,10 @@ class TestAmazonS3FileValidator(object):
         assert not amazon_s3_file_validator.obj.key.startswith(
             'test-unvalidated-uploads/'
         )
+
+    def test_validate_preserves_content_type(self, amazon_s3_file_validator):
+        amazon_s3_file_validator.validate()
+        assert amazon_s3_file_validator.obj.content_type == 'application/custom.test'
 
     def test_validate_doesnt_remove_unvalidated_prefix_file(
         self,

--- a/tests/test_amazon_s3_file_validator.py
+++ b/tests/test_amazon_s3_file_validator.py
@@ -93,6 +93,7 @@ class TestAmazonS3FileValidator(object):
         self,
         amazon_s3_file_validator
     ):
+        amazon_s3_file_validator.validate()
         assert not amazon_s3_file_validator.errors
 
     def test_validate_returns_false_when_validation_fails(


### PR DESCRIPTION
This fixes an issue, where pdf file content type was sometimes set to `application/octet-stream` and sometimes `application/pdf`. The unvalidated S3 object had correct content type `application/pdf`, but the content type was not copied to the validated object.